### PR TITLE
PIC24 programming support

### DIFF
--- a/hex.c
+++ b/hex.c
@@ -63,6 +63,16 @@ void hexSetBytesPerAddress(unsigned char bytes)
 bytesPerAddress = bytes; 		
 }
 
+/**************************************************************************** 		
+Function : hexGetBytesPerAddress 		
+Description : returns set byte width 		
+Parameters : Nothing (void)  		
+Returns : unsigned char Bytes per address 		
+****************************************************************************/ 
+unsigned char hexGetBytesPerAddress(void){
+    return bytesPerAddress;
+}
+
 /****************************************************************************
  Function    : hexOpen
  Description : Open and memory-map an Intel hex file.
@@ -124,7 +134,7 @@ static int verifyBlockProgrammable( unsigned int *addr, char *len )
 
 		/* calc if first or last address is in this block */
 		MA = devQuery.mem[ i ].Address;
-		ML = devQuery.mem[ i ].Length;
+		ML = devQuery.mem[ i ].Length * bytesPerAddress;
 		isA = ( *addr >= MA ) && ( *addr < MA + ML );
 		isL = ( *addr + *len > MA ) && ( *addr + *len <= MA + ML );
 

--- a/main.c
+++ b/main.c
@@ -165,22 +165,15 @@ int main(
 
 		/* And start doing stuff... */
 
-		(void)printf("USB HID device found");
+		(void)printf("USB HID device found\n");
 		usbBuf[0] = QUERY_DEVICE;
 		if(ERR_NONE == (status = usbWrite(1,1))) {
 			memcpy( &devQuery, usbBuf, 64 );
 			i = 0;
 			while ( devQuery.mem[ i ].Type != TypeEndOfTypeList ) i++;
 			devQuery.memBlocks = i;
-			for ( i = 0; i < devQuery.memBlocks; i++ ) {
-			  devQuery.mem[i].Address = convertEndian(devQuery.mem[i].Address);
-			  devQuery.mem[i].Length = convertEndian(devQuery.mem[i].Length);
-			  if(devQuery.mem[i].Type == TypeProgramMemory) {
-			    (void)printf(": %d bytes free\n",devQuery.mem[i].Length);
-			    }
-			}
-
-			(void)printf("Device family: ");
+			
+            (void)printf("Device family: ");
  			switch (devQuery.DeviceFamily)
 				{
 				case DEVICE_FAMILY_PIC18:
@@ -200,8 +193,14 @@ int main(
 					(void)printf("Unknown. Bytes per address set to 1.\n");
 					break;
 			}
-
-
+            (void)printf("Memory");   
+            for ( i = 0; i < devQuery.memBlocks; i++ ) {
+			  devQuery.mem[i].Address = convertEndian(devQuery.mem[i].Address);
+			  devQuery.mem[i].Length = convertEndian(devQuery.mem[i].Length);
+			  if(devQuery.mem[i].Type == TypeProgramMemory) {
+                (void)printf(": %d bytes free, addr: %04x, total %d\n",devQuery.mem[i].Length*hexGetBytesPerAddress(),devQuery.mem[i].Address,devQuery.memBlocks);  
+			    }
+			}
 		}
 		(void)putchar('\n');
 

--- a/mphidflash.h
+++ b/mphidflash.h
@@ -116,6 +116,7 @@ typedef enum
 	ERR_EOL              /* End-of-list, not actual error code */
 } ErrorCode;
 
+
 /* Function prototypes */
 
 extern ErrorCode
@@ -127,6 +128,7 @@ extern void
 	hexClose(void),
 	usbClose(void),
 	hexSetBytesPerAddress(unsigned char);
+extern unsigned char hexGetBytesPerAddress(void);
 
 #pragma pack( push )
 #pragma pack( 1 )


### PR DESCRIPTION
Function verifyBlockProgrammable takes into account the number of bytes per address.
PIC family recognition was moved upwards to enable proper memory print.